### PR TITLE
Fixes ordering on Task 5

### DIFF
--- a/tests/test_task_05.py
+++ b/tests/test_task_05.py
@@ -56,7 +56,8 @@ class Task05TestCase(unittest.TestCase):
         cm.log = [('a', 'b')]
         cm.reset()
         self.assertEqual(cm.log, [])
-        self.assertEqual(cm.pieces.keys(), self.starting_positions.keys())
+        self.assertEqual(set(cm.pieces.keys()),
+                         set(self.starting_positions.keys()))
 
     def test_move_log(self):
         """Tests that the move operation logs a move."""


### PR DESCRIPTION
Fix to remove ordering restriction on task 5's tests.
